### PR TITLE
Add null check for `client`

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -2,5 +2,7 @@
 
 workspace.windowActivated.connect(function(client) {
     //console.log("CLIENT PID", client.pid);
-    callDBus("com.system76.Scheduler", "/com/system76/Scheduler", "com.system76.Scheduler", "SetForegroundProcess", client.pid);
+    if (client != null) {
+        callDBus("com.system76.Scheduler", "/com/system76/Scheduler", "com.system76.Scheduler", "SetForegroundProcess", client.pid);
+    }
 })


### PR DESCRIPTION
The `client` can be null occasionally when windowActivated is triggered (not exactly sure why) and producing the below warning message:

file:///usr/share/kwin/scripts/kwin-system76-scheduler-integration/contents/code/main.js:5: TypeError: Cannot read property 'pid' of null

While this warning is not harmful, it is polluting the logs. The warning should not appearing anymore with the null check.